### PR TITLE
fix(api): honour ASPNETCORE_URLS instead of the pinned Kestrel endpoint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,10 +124,9 @@ jobs:
           if [ -f "$EXE.exe" ]; then EXE="$EXE.exe"; else chmod +x "$EXE"; fi
 
           export ASPNETCORE_ENVIRONMENT=Production
-          # appsettings.json pins an explicit Kestrel endpoint, which outranks ASPNETCORE_URLS.
-          # Environment variables do outrank appsettings, so bind the probe port this way and
-          # stay off 8080 in case something else on the runner holds it.
-          export Kestrel__Endpoints__Http__Url=http://127.0.0.1:8099
+          # Bind the probe port through the documented variable — that is exactly what proves it
+          # reaches Kestrel. Deliberately off 8080 in case something else on the runner holds it.
+          export ASPNETCORE_URLS=http://127.0.0.1:8099
           # Mirror the container: a separate bundle extraction directory, so a data directory
           # resolved from AppContext.BaseDirectory would land there and be caught below.
           export DOTNET_BUNDLE_EXTRACT_BASE_DIR="$EXTRACT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ Docker images are published per tag to
 binaries and auto-generated notes are on the
 [GitHub Releases](https://github.com/ingel81/knx-ng-monitor/releases) page.
 
+## [Unreleased]
+
+### Fixed
+- **`ASPNETCORE_URLS` is honoured again.** Setting it did nothing - neither for the
+  portable binary nor in Docker, where the image sets it itself: the app always came up
+  on 8080. The shipped `appsettings.json` pinned an explicit Kestrel endpoint, and a
+  configured endpoint outranks the address list the variable feeds. The pin is gone; the
+  default `http://0.0.0.0:8080` now lives in code and applies only when nothing else
+  configures an address. `ASPNETCORE_HTTP_PORTS` and `ASPNETCORE_HTTPS_PORTS` were just as
+  inert and now take effect too. Unchanged: the default port and interface, and
+  `Kestrel__Endpoints__Http__Url`, which was the one way around the pin and keeps winning.
+
 ## [0.10.0]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ dotnet run --project KnxMonitor.Api                                    # http://
 
 # Tests — parser library carries the bulk of the coverage
 dotnet test KnxMonitor.ProjectParser.Tests/KnxMonitor.ProjectParser.Tests.csproj
+dotnet test KnxMonitor.Infrastructure.Tests/KnxMonitor.Infrastructure.Tests.csproj
 
 # Coverage (cobertura → coverage-tmp/, ignored by git)
 dotnet test KnxMonitor.ProjectParser.Tests/KnxMonitor.ProjectParser.Tests.csproj \
@@ -200,7 +201,7 @@ Migrations live in `backend/KnxMonitor.Infrastructure/Data/Migrations/`.
 | Variable | Default | Purpose |
 |---|---|---|
 | `ASPNETCORE_ENVIRONMENT` | `Production` | `Development` enables CORS for `:4200` and Scalar OpenAPI docs |
-| `ASPNETCORE_URLS` | `http://+:8080` | Listen URL |
+| `ASPNETCORE_URLS` | `http://0.0.0.0:8080` | Listen URL. Der Default kommt aus `HostingUrls.ResolveFallbackListenUrl` und greift nur, wenn weder `urls`/`ASPNETCORE_HTTP_PORTS`/`ASPNETCORE_HTTPS_PORTS` noch ein `Kestrel:Endpoints`-Abschnitt gesetzt sind — er darf **nicht** zurück in `appsettings.json` wandern (das stach die Adressliste, #9). Das Docker-Image setzt das äquivalente `http://+:8080` |
 
 `./data/.jwt-secret` is auto-generated on first start; never commit it.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -127,6 +127,12 @@ backend on `http://localhost:8080`, and CORS for `:4200` is enabled. In
 `Production` the backend serves the prebuilt Angular bundle directly (single
 port).
 
+The `:8080` default now lives in code and steps aside for anything that
+configures an address - a local (gitignored) `Properties/launchSettings.json`
+with an `applicationUrl` among it. If yours points somewhere else, `dotnet run`
+comes up on that port and the Angular proxy finds nothing: either drop the key,
+set it to `http://localhost:8080`, or run with `--no-launch-profile`.
+
 ### Local production build (mirrors GitHub Actions)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ types and room/building context. The two-stage wizard walks through:
 | Variable | Default | Purpose |
 |---|---|---|
 | `ASPNETCORE_ENVIRONMENT` | `Production` | `Development` enables CORS for `:4200`, the separate dev server and the scalar/v1 API docs |
-| `ASPNETCORE_URLS` | `http://+:8080` | Listen URL - change to use a different port |
+| `ASPNETCORE_URLS` | `http://0.0.0.0:8080` | Listen URL - change to use a different port. Up to 0.10.0 the shipped `appsettings.json` pinned the endpoint and silently outranked this variable; it is honoured now. Alternatives: `ASPNETCORE_HTTP_PORTS`, `ASPNETCORE_HTTPS_PORTS`, `Kestrel__Endpoints__Http__Url`, or a `Urls` key in `appsettings.json` - each of them wins over the default. The Docker image sets the equivalent `http://+:8080`; inside a container leave the port at 8080 (the `HEALTHCHECK` probes it) and remap on the host with `-p HOST:8080` |
 | `KNX_LOG_LEVEL` | `Information` | Log verbosity: `Verbose`, `Debug`, `Information`, `Warning`, `Error`, `Fatal` (see [Logging & diagnostics](#logging--diagnostics)) |
 
 ### Data directory

--- a/backend/KnxMonitor.Api/Program.cs
+++ b/backend/KnxMonitor.Api/Program.cs
@@ -106,6 +106,17 @@ builder.Services.Configure<Microsoft.AspNetCore.Http.Features.FormOptions>(o =>
 });
 builder.WebHost.ConfigureKestrel(o => o.Limits.MaxRequestBodySize = MaxUploadBytes);
 
+// Standard-Adresse 0.0.0.0:8080, aber nur wenn wirklich nichts anderes eine Adresse setzt.
+// Sie darf nicht in appsettings.json stehen: ein dort konfigurierter Kestrel-Endpunkt sticht die
+// Adressliste und machte ASPNETCORE_URLS damit wirkungslos (#9). Muss vor builder.Build() laufen —
+// app.Urls.Add() danach wirft im OpenAPI-Generator (genau dafür gibt es BoundUrls()), und
+// ConfigureKestrel(o => o.ListenAnyIP(...)) ließe app.Urls leer, womit Startmeldung und
+// Browser-Start still nichts mehr täten.
+if (HostingUrls.ResolveFallbackListenUrl(builder.Configuration) is { } fallbackUrl)
+{
+    builder.WebHost.UseUrls(fallbackUrl);
+}
+
 // Rate limiting — throttle the anonymous auth endpoints against brute force.
 builder.Services.AddRateLimiter(options =>
 {
@@ -448,8 +459,10 @@ try
 
         var primaryUrl = urls[0];
 
-        // Convert 0.0.0.0 to localhost for display (0.0.0.0 doesn't work in browsers)
-        var displayUrl = primaryUrl.Replace("0.0.0.0", "localhost");
+        // Platzhalter-Host auf localhost drehen, der Browser kann mit 0.0.0.0 nichts anfangen.
+        // Seit #9 wirkt ASPNETCORE_URLS auch im Container, und dessen http://+:8080 taucht hier
+        // als gebundenes http://[::]:8080 auf — das traf das frühere Replace("0.0.0.0", …) nicht.
+        var displayUrl = HostingUrls.ToBrowsableUrl(primaryUrl);
 
         // Log the URL(s) - modern terminals will make these clickable
         Log.Information("====================================");
@@ -467,7 +480,7 @@ try
             Log.Information("Access the application at: {Url}", displayUrl);
             foreach (var url in urls.Skip(1))
             {
-                var altDisplayUrl = url.Replace("0.0.0.0", "localhost");
+                var altDisplayUrl = HostingUrls.ToBrowsableUrl(url);
                 Log.Information("Alternative URL: {Url}", altDisplayUrl);
             }
         }
@@ -565,8 +578,9 @@ static void OpenBrowser(string url)
 {
     try
     {
-        // Convert 0.0.0.0 to localhost for browser
-        url = url.Replace("0.0.0.0", "localhost");
+        // Platzhalter-Host (0.0.0.0, [::], +, *) auf localhost drehen — sonst öffnet der Browser
+        // eine Adresse, die er nicht auflösen kann.
+        url = HostingUrls.ToBrowsableUrl(url);
 
         if (OperatingSystem.IsWindows())
         {

--- a/backend/KnxMonitor.Api/appsettings.json
+++ b/backend/KnxMonitor.Api/appsettings.json
@@ -16,12 +16,5 @@
     "Audience": "knx-ng-monitor-client",
     "AccessTokenExpirationMinutes": 15,
     "RefreshTokenExpirationDays": 7
-  },
-  "Kestrel": {
-    "Endpoints": {
-      "Http": {
-        "Url": "http://0.0.0.0:8080"
-      }
-    }
   }
 }

--- a/backend/KnxMonitor.Infrastructure.Tests/HostingUrlsTests.cs
+++ b/backend/KnxMonitor.Infrastructure.Tests/HostingUrlsTests.cs
@@ -1,0 +1,83 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace KnxMonitor.Infrastructure.Tests;
+
+/// <summary>
+/// Covers issue #9: setting <c>ASPNETCORE_URLS</c> had no effect, in Docker as well. The shipped
+/// appsettings.json pinned <c>Kestrel:Endpoints:Http:Url</c>, and a config-backed Kestrel endpoint
+/// outranks the address list the variable feeds — so the app kept listening on 8080 whatever the
+/// user asked for. The default now lives in <see cref="HostingUrls"/> and steps aside as soon as
+/// anything else configures an address.
+/// </summary>
+public class HostingUrlsTests
+{
+    /// <summary>
+    /// Reads the real file (linked into the test output by the csproj) rather than going through
+    /// configuration layering: the question is whether the SHIPPED file on its own pins an endpoint.
+    /// </summary>
+    [Fact]
+    public void ShippedAppSettings_DoesNotPinTheListenEndpoint()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "ApiConfig", "appsettings.json");
+        File.Exists(path).Should().BeTrue($"the API's appsettings.json should be linked to {path}");
+
+        using var document = JsonDocument.Parse(File.ReadAllText(path));
+
+        document.RootElement.TryGetProperty("Kestrel", out _).Should().BeFalse(
+            "a Kestrel endpoint in appsettings.json outranks ASPNETCORE_URLS and makes it inert");
+    }
+
+    [Theory]
+    // Nothing configured anywhere — this is the case the built-in default exists for.
+    [InlineData(null, null, null, null, HostingUrls.DefaultListenUrl)]
+    // An empty value is not configuration.
+    [InlineData("", null, null, null, HostingUrls.DefaultListenUrl)]
+    // ASPNETCORE_URLS / DOTNET_URLS / --urls / launchSettings all land in the "urls" key.
+    [InlineData("http://127.0.0.1:9000", null, null, null, null)]
+    // ASPNETCORE_HTTP_PORTS / ASPNETCORE_HTTPS_PORTS.
+    [InlineData(null, "9000", null, null, null)]
+    [InlineData(null, null, "9001", null, null)]
+    // A hand-added Kestrel endpoint must keep winning — without an "Overriding address(es)" warning.
+    [InlineData(null, null, null, "http://127.0.0.1:8099", null)]
+    public void ResolveFallbackListenUrl_StepsAsideWheneverAnAddressIsConfigured(
+        string? urls, string? httpPorts, string? httpsPorts, string? kestrelUrl, string? expected)
+    {
+        // null means "key absent" here — a key present with a null value would still show up as a
+        // section child and is a different case (covered by the empty-string row for "urls").
+        var settings = new Dictionary<string, string?>
+        {
+            ["urls"] = urls,
+            ["HTTP_PORTS"] = httpPorts,
+            ["HTTPS_PORTS"] = httpsPorts,
+            ["Kestrel:Endpoints:Http:Url"] = kestrelUrl
+        }.Where(pair => pair.Value is not null);
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+
+        HostingUrls.ResolveFallbackListenUrl(configuration).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// LAN/mobile testing and <c>docker run -p 8080:8080</c> all break the moment this is tidied
+    /// into a localhost-only binding.
+    /// </summary>
+    [Fact]
+    public void DefaultListenUrl_BindsAllInterfaces()
+    {
+        HostingUrls.DefaultListenUrl.Should().StartWith("http://0.0.0.0:");
+    }
+
+    [Theory]
+    [InlineData("http://0.0.0.0:8080", "http://localhost:8080")]
+    [InlineData("http://[::]:8080", "http://localhost:8080")]
+    [InlineData("http://+:8080", "http://localhost:8080")]
+    [InlineData("http://*:8080", "http://localhost:8080")]
+    [InlineData("http://127.0.0.1:8099", "http://127.0.0.1:8099")]
+    public void ToBrowsableUrl_NormalisesWildcardHostsOnly(string bound, string expected)
+    {
+        HostingUrls.ToBrowsableUrl(bound).Should().Be(expected);
+    }
+}

--- a/backend/KnxMonitor.Infrastructure.Tests/KnxMonitor.Infrastructure.Tests.csproj
+++ b/backend/KnxMonitor.Infrastructure.Tests/KnxMonitor.Infrastructure.Tests.csproj
@@ -26,6 +26,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The real shipped configuration, so a test can assert what it does (not) contain.
+         Deliberately linked into a subfolder: dropped into the output root the test host would
+         pick it up as its own configuration. -->
+    <None Include="..\KnxMonitor.Api\appsettings.json" Link="ApiConfig\appsettings.json"
+          CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\KnxMonitor.Core\KnxMonitor.Core.csproj" />
     <ProjectReference Include="..\KnxMonitor.Infrastructure\KnxMonitor.Infrastructure.csproj" />
   </ItemGroup>

--- a/backend/KnxMonitor.Infrastructure/HostingUrls.cs
+++ b/backend/KnxMonitor.Infrastructure/HostingUrls.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.Configuration;
+
+namespace KnxMonitor.Infrastructure;
+
+/// <summary>
+/// Decides which address the API listens on when nothing else says.
+/// <para>
+/// Up to 0.10.0 the shipped appsettings.json carried a <c>Kestrel:Endpoints:Http:Url</c> entry.
+/// A config-backed Kestrel endpoint outranks the address list, so <c>ASPNETCORE_URLS</c> was
+/// silently ignored — in Docker as well, where the image sets it (issue #9). The default therefore
+/// lives here in code and only applies when the address list is genuinely empty.
+/// </para>
+/// <para>
+/// The Kestrel:Endpoints guard in <see cref="ResolveFallbackListenUrl"/> is not cosmetic: without
+/// it we would populate the address list while Kestrel still binds the configured endpoint, which
+/// produces an "Overriding address(es)" warning and — worse — a startup banner and auto-opened
+/// browser pointing at an address nothing listens on.
+/// </para>
+/// <para>
+/// The default binds all interfaces, never localhost. Testing from a phone in the LAN and
+/// <c>docker run -p 8080:8080</c> both depend on it.
+/// </para>
+/// </summary>
+public static class HostingUrls
+{
+    public const string DefaultListenUrl = "http://0.0.0.0:8080";
+
+    /// <summary>
+    /// Returns <see cref="DefaultListenUrl"/> when no address was configured anywhere, otherwise
+    /// null — meaning "hands off, someone else decides".
+    /// <para>
+    /// The keys checked are the ones the host itself reads after the <c>ASPNETCORE_</c> /
+    /// <c>DOTNET_</c> prefix has been stripped: <c>urls</c> (ASPNETCORE_URLS, DOTNET_URLS,
+    /// <c>--urls</c>, launchSettings' applicationUrl and an appsettings <c>Urls</c> key all land
+    /// there), <c>HTTP_PORTS</c> / <c>HTTPS_PORTS</c>, and any <c>Kestrel:Endpoints</c> child.
+    /// </para>
+    /// </summary>
+    public static string? ResolveFallbackListenUrl(IConfiguration configuration)
+    {
+        if (!string.IsNullOrWhiteSpace(configuration["urls"])
+            || !string.IsNullOrWhiteSpace(configuration["HTTP_PORTS"])
+            || !string.IsNullOrWhiteSpace(configuration["HTTPS_PORTS"])
+            || configuration.GetSection("Kestrel:Endpoints").GetChildren().Any())
+        {
+            return null;
+        }
+
+        return DefaultListenUrl;
+    }
+
+    /// <summary>
+    /// Rewrites the wildcard host of a bound address to localhost so it can be clicked in a
+    /// terminal or handed to a browser. Kestrel reports every one of these forms depending on how
+    /// the address was written — the container image uses <c>http://+:8080</c>, which surfaces as
+    /// <c>http://[::]:8080</c>.
+    /// <para>
+    /// Plain string replacement, not <see cref="Uri"/> parsing: the display names always carry the
+    /// port, and <c>+</c> / <c>*</c> are not legal Uri hosts, so parsing would throw on them.
+    /// </para>
+    /// </summary>
+    public static string ToBrowsableUrl(string url) => url
+        .Replace("://0.0.0.0:", "://localhost:", StringComparison.Ordinal)
+        .Replace("://[::]:", "://localhost:", StringComparison.Ordinal)
+        .Replace("://+:", "://localhost:", StringComparison.Ordinal)
+        .Replace("://*:", "://localhost:", StringComparison.Ordinal);
+}


### PR DESCRIPTION
Setting `ASPNETCORE_URLS` had no effect on the listen address — not for the portable binary and not in Docker, where the image sets the variable itself: the app always came up on 8080. The cause was the shipped `backend/KnxMonitor.Api/appsettings.json`, which pinned `Kestrel:Endpoints:Http:Url`; a config-backed Kestrel endpoint outranks the address list that `ASPNETCORE_URLS` / `DOTNET_URLS` / `--urls` feed, so the variable was silently ignored. This PR deletes that pin and moves the `http://0.0.0.0:8080` default into code, where it is applied via `builder.WebHost.UseUrls()` before `builder.Build()` and only when nothing else configured an address. Default port and interface are unchanged, and `Kestrel__Endpoints__Http__Url` / `ASPNETCORE_HTTP_PORTS` keep winning over the default.

## Changes

**Configuration**
- `backend/KnxMonitor.Api/appsettings.json`: removed the entire `Kestrel` block (`Endpoints:Http:Url = http://0.0.0.0:8080`). It was the only `Kestrel` key in the file and the sole cause of the bug; `appsettings.Development.json` has none.

**New helper (`backend/KnxMonitor.Infrastructure/HostingUrls.cs`)**
- `DefaultListenUrl = "http://0.0.0.0:8080"`.
- `ResolveFallbackListenUrl(IConfiguration)` returns that default only when the address list is genuinely empty, otherwise `null` ("hands off"). It steps aside for the `urls` key (where `ASPNETCORE_URLS`, `DOTNET_URLS`, `--urls`, launchSettings' `applicationUrl` and an appsettings `Urls` key all land after prefix stripping), for `HTTP_PORTS` / `HTTPS_PORTS`, and for any `Kestrel:Endpoints` child. The last guard matters: without it the address list would be populated while Kestrel binds the configured endpoint, producing an "Overriding address(es)" warning plus a startup banner and auto-opened browser pointing at a dead address. Empty values count as unset (`IsNullOrWhiteSpace`).
- `ToBrowsableUrl(string)` rewrites the wildcard hosts `0.0.0.0`, `[::]`, `+` and `*` to `localhost` by ordinal replace on the `://host:` form. No `Uri` parsing — `+` and `*` are not legal Uri hosts and would throw.
- Pure static, `IConfiguration` only (from `Configuration.Abstractions`, already present transitively via `Microsoft.Extensions.Options.ConfigurationExtensions`). No ASP.NET Core types leak into Infrastructure and no new `PackageReference` was needed.

**`backend/KnxMonitor.Api/Program.cs`**
- Directly after the existing `ConfigureKestrel` call and well before `builder.Build()`: `if (HostingUrls.ResolveFallbackListenUrl(builder.Configuration) is { } fallbackUrl) builder.WebHost.UseUrls(fallbackUrl);`. The comment records why the two alternatives are wrong — `app.Urls.Add()` after `Build()` throws in the build-time OpenAPI generator (which is what `BoundUrls()` guards against), and `ConfigureKestrel(o => o.ListenAnyIP(...))` would leave `app.Urls` empty, silently disabling the startup banner and auto-open-browser (both early-return on an empty list).
- The three literal `.Replace("0.0.0.0", "localhost")` sites (`displayUrl`, `altDisplayUrl` in the `Skip(1)` loop, and `OpenBrowser`) now call `HostingUrls.ToBrowsableUrl`. This is a direct consequence of the fix: the container's `ASPNETCORE_URLS=http://+:8080` now actually takes effect and surfaces as a bound `http://[::]:8080`, which the old literal replace could not normalise.
- `BoundUrls()`, the `HTTPS_PORT` heuristic and the banner structure are untouched.

**Tests**
- `backend/KnxMonitor.Infrastructure.Tests/HostingUrlsTests.cs` (new): `ShippedAppSettings_DoesNotPinTheListenEndpoint` parses the real shipped `appsettings.json` with `JsonDocument` and asserts the root declares no `Kestrel` property — read as a file rather than through configuration layering, because the question is what the shipped file alone does. Plus contract pins: a 6-row theory over `ResolveFallbackListenUrl` (empty config → default; `urls` / `HTTP_PORTS` / `HTTPS_PORTS` / `Kestrel:Endpoints:Http:Url` each → `null`; `urls=""` → default), `DefaultListenUrl_BindsAllInterfaces`, and a 5-row `ToBrowsableUrl` theory covering `0.0.0.0`, `[::]`, `+`, `*` and an untouched `127.0.0.1`.
- `KnxMonitor.Infrastructure.Tests.csproj`: one `<None Include="..\KnxMonitor.Api\appsettings.json" Link="ApiConfig\appsettings.json" CopyToOutputDirectory="PreserveNewest" />`, following the repo's existing file-linking pattern. Deliberately linked into a subfolder so the test host cannot pick it up as its own configuration. No new `PackageReference` and no `ProjectReference` to `KnxMonitor.Api`.

**CI**
- `.github/workflows/release.yml`: the published-binary smoke test now exports `ASPNETCORE_URLS=http://127.0.0.1:8099` instead of `Kestrel__Endpoints__Http__Url=...`, making the release workflow an end-to-end proof that the variable reaches Kestrel. The comment above it previously documented the bug as current behaviour and was rewritten. Probe URLs and the docker smoke test's `-p 8099:8080` are unchanged.

**Docs**
- `README.md` / `CLAUDE.md`: environment-variable tables now list the default as `http://0.0.0.0:8080` (same literal in both, so they cannot drift apart again), note that the variable is genuinely honoured, list the alternatives (`ASPNETCORE_HTTP_PORTS`, `ASPNETCORE_HTTPS_PORTS`, `Kestrel__Endpoints__Http__Url`, an appsettings `Urls` key — the same four checks `ResolveFallbackListenUrl` makes), and state that inside a container the port should stay 8080 because the `HEALTHCHECK` probes it — remap on the host with `-p HOST:8080`.
- `CLAUDE.md` also gains the `KnxMonitor.Infrastructure.Tests` command next to the existing `ProjectParser.Tests` one. The new regression pin lives in that project, and until now nothing told a contributor to run it.
- `DEVELOPMENT.md`: added the launchSettings caveat — a local, gitignored `Properties/launchSettings.json` with an `applicationUrl` now genuinely outranks the built-in default and breaks the `:8080` Angular proxy; drop the key, point it at `http://localhost:8080`, or use `--no-launch-profile`.
- `CHANGELOG.md`: new `## [Unreleased]` / `### Fixed` entry above `[0.10.0]` (symptom, mechanism, what stays unchanged).

## Verification

Automated:
- `dotnet test backend/KnxMonitor.Infrastructure.Tests/KnxMonitor.Infrastructure.Tests.csproj --nologo` → 68 passed, 0 failed. Note that the repo's default backend test gate covers `ProjectParser.Tests` only, which is why `Infrastructure.Tests` is called out explicitly here.
- Red-before-green evidence, captured before `appsettings.json` was touched:
  ```
  Fehler KnxMonitor.Infrastructure.Tests.HostingUrlsTests.ShippedAppSettings_DoesNotPinTheListenEndpoint [28 ms]
  Fehlermeldung: Expected document.RootElement.TryGetProperty("Kestrel", out _) to be false because
  a Kestrel endpoint in appsettings.json outranks ASPNETCORE_URLS and makes it inert, but found True.
  ...
  Fehler: 1, erfolgreich: 12, gesamt: 13
  ```
  Exactly the reproduction test failed while all 12 contract pins were already green.
- `dotnet build backend/KnxMonitor.sln -c Debug --nologo` — this executes the app entry point for `OpenApiGenerateDocuments`, i.e. the no-server path `BoundUrls()` guards. Build green and `git status --short` shows no diff for the tracked `docs/api/openapi.json`.

Manual — not coverable by tests, because the solution has no Api test project and no `WebApplicationFactory`, so nothing can assert that Kestrel really binds the resolved address. All five cases were run against the built binary with stdout redirected (which also keeps the auto-open-browser guard shut), probing `/healthz` and checking the startup banner and the Kestrel log:

| Case | Environment | `/healthz` | `:8080` | Banner URL | "Overriding address(es)" |
|---|---|---|---|---|---|
| a | *(none)* | `:8080` ✓ | — | `http://localhost:8080` | no |
| b | `ASPNETCORE_URLS=http://127.0.0.1:9000` | `:9000` ✓ | silent | `http://127.0.0.1:9000` | no |
| c | `ASPNETCORE_HTTP_PORTS=9001` | `:9001` ✓ | silent | `http://localhost:9001` | no |
| d | `Kestrel__Endpoints__Http__Url=http://127.0.0.1:8099` | `:8099` ✓ | silent | `http://127.0.0.1:8099` | no |
| e | `ASPNETCORE_URLS=http://+:8098` | `:8098` ✓ | — | `http://localhost:8098` | no |

Case a proves the code-level default replaces the deleted pin. Case b is the reported bug, now fixed — the app moves off 8080 entirely. Case d is the pre-fix workaround the release workflow used and must keep working; the absent override warning shows the `Kestrel:Endpoints` arm of the guard doing its job. Case e shows `ToBrowsableUrl` normalising what the container's `http://+:8080` surfaces as, which the old literal `.Replace("0.0.0.0", …)` could not.

Not run: the Docker case (`docker build && docker run -p 8099:8080` → reachable on 8099, container-internal still 8080 so the `HEALTHCHECK` stays green). The image sets `ASPNETCORE_URLS` itself, so it takes the same path as case b/e above.

Note for local development: a gitignored `Properties/launchSettings.json` with an `applicationUrl` now genuinely wins, so `dotnet run` needs `--no-launch-profile` — or that key removed — to observe the built-in default. This is what the new `DEVELOPMENT.md` paragraph documents.

## Notes

- The docs deliberately name no version for the fix: `CHANGELOG.md` carries it under `## [Unreleased]` and that entry is the single place a version gets stamped at release time. The README states the behaviour relative to 0.10.0 instead, so it stays true whichever number the next tag gets.
- Known gap, not addressed here: no workflow in this repo runs `dotnet test` at all — `release.yml` is the only one. The new regression pin therefore only fires when a contributor runs `Infrastructure.Tests` (now documented in `CLAUDE.md`). Adding a test job is worth its own issue rather than being smuggled into this fix. For the same reason the release smoke test was left probing 8099 rather than gaining a bare-default start on 8080: that step deliberately stays off 8080 in case something on the runner holds it, so such an assertion would be flaky.
- The `Dockerfile` is deliberately untouched. `ENV ASPNETCORE_URLS=http://+:8080` stays as-is — `+` is the correct all-interfaces wildcard for a container and narrowing it to `0.0.0.0` would drop IPv6 — and `EXPOSE` / `HEALTHCHECK` keep their hardcoded 8080. The image's variable simply becomes effective for the first time.
- No frontend change: both environment files use relative `/api` and `/hubs` paths, and `proxy.conf.json` stays at `:8080` because the default port is unchanged.
- Nothing EF/DI/SignalR-related is touched — no entity, DTO, interface, repository, registration or hub surface changed, and there is no migration.
- `publish/appsettings.json` and `backend/KnxMonitor.Api/bin/**/appsettings.json` still carry the old `Kestrel` section. They are gitignored build outputs and are regenerated on the next build; they were deliberately not hand-edited.

Closes #9